### PR TITLE
Added sorting of log files

### DIFF
--- a/libraries/Fire_log.php
+++ b/libraries/Fire_log.php
@@ -97,8 +97,10 @@ class Fire_log{
 				array_push( $filtered_list, $file ); 
 
 			}
+			//Order list by file name
+			usort($filtered_list, create_function('$a, $b', 'return strcmp($b["name"], $a["name"]);'));
 
-			return array_reverse( $filtered_list );
+			return $filtered_list;
 		}
 
 		public function get_file( $log_file )


### PR DESCRIPTION
On my Linux server the log files appear in what the order in which they are stored by the filesystem (http://php.net/manual/en/function.readdir.php). Since finding a specific log files is kind of annoying when they are unordered I added a simple sorting in list_files() before returning it to the view.
