### PR TITLE
Issue #3, nothing shown if the number of log lines are less than 75

### DIFF
--- a/libraries/Fire_log.php
+++ b/libraries/Fire_log.php
@@ -213,6 +213,10 @@ class Fire_log{
 					$lines += 75;
 				}
 			}
+			
+			if ( !empty( $buffer )) {
+				array_push( $this->pages, $buffer );
+			}			
 
 			fclose ($handle);
 


### PR DESCRIPTION
If the number of lines in the log file are less than 75, nothing is shown because the buffer is passed to $this->pages only every 75:th line
